### PR TITLE
Add minimal ontology generation script

### DIFF
--- a/open-data-layer/README.md
+++ b/open-data-layer/README.md
@@ -25,3 +25,18 @@ contains placeholder content that can be replaced with real implementations.
 ├── LICENSE
 └── README.md
 ```
+
+## Generating the Example Ontology
+
+The `ontology` folder includes a small OWL file and a helper script for
+converting it to JSON-LD. To generate `workflow/workflow.jsonld` run:
+
+```bash
+pip install rdflib
+python ontology/generate_ontology.py
+```
+
+The script loads `ontology/open_data_ontology.owl` and writes a JSON-LD
+representation in the repository's `workflow` directory. The produced
+`workflow.jsonld` aligns with the classes and properties defined in the OWL
+example.

--- a/open-data-layer/ontology/generate_ontology.py
+++ b/open-data-layer/ontology/generate_ontology.py
@@ -1,4 +1,21 @@
-"""Placeholder script for ontology generation."""
+"""Simple example for converting the sample OWL ontology to JSON-LD."""
+
+from pathlib import Path
+from rdflib import Graph
+
+
+def convert_ontology(owl_path: Path, output_path: Path) -> None:
+    """Load ``owl_path`` and write a JSON-LD representation to ``output_path``."""
+    g = Graph()
+    g.parse(owl_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    g.serialize(destination=str(output_path), format="json-ld", indent=2)
+
 
 if __name__ == "__main__":
-    print("Generate ontology here")
+    here = Path(__file__).resolve().parent
+    owl_file = here / "open_data_ontology.owl"
+    root = here.parent.parent
+    workflow_jsonld = root / "workflow" / "workflow.jsonld"
+    convert_ontology(owl_file, workflow_jsonld)
+    print(f"Generated {workflow_jsonld}")

--- a/open-data-layer/ontology/open_data_ontology.owl
+++ b/open-data-layer/ontology/open_data_ontology.owl
@@ -1,1 +1,18 @@
-<!-- Placeholder ontology -->
+<?xml version="1.0"?>
+<rdf:RDF xmlns="https://openpermit.org/ontologies/openpermit#"
+     xml:base="https://openpermit.org/ontologies/openpermit"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+    <owl:Ontology rdf:about="https://openpermit.org/ontologies/openpermit"/>
+
+    <owl:Class rdf:about="https://openpermit.org/ontologies/openpermit#Permit"/>
+    <owl:Class rdf:about="https://openpermit.org/ontologies/openpermit#Application"/>
+
+    <owl:ObjectProperty rdf:about="https://openpermit.org/ontologies/openpermit#hasApplication">
+        <rdfs:domain rdf:resource="https://openpermit.org/ontologies/openpermit#Permit"/>
+        <rdfs:range rdf:resource="https://openpermit.org/ontologies/openpermit#Application"/>
+    </owl:ObjectProperty>
+</rdf:RDF>

--- a/workflow/workflow.jsonld
+++ b/workflow/workflow.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "@vocab": "https://openpermit.org/ontologies/openpermit#"
+  },
+  "@id": "https://openpermit.org/workflow/example",
+  "@type": "Permit",
+  "hasApplication": {
+    "@type": "Application",
+    "description": "Sample application linked from the workflow"
+  }
+}


### PR DESCRIPTION
## Summary
- create a tiny example ontology in `open_data_ontology.owl`
- convert OWL to JSON-LD with `generate_ontology.py`
- document generation steps in `open-data-layer/README.md`
- add sample `workflow/workflow.jsonld` demonstrating use of the ontology

## Testing
- `python open-data-layer/ontology/generate_ontology.py` *(fails: ModuleNotFoundError: No module named 'rdflib')*