### PR TITLE
Add workflow validation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,3 +254,7 @@ Risk‑ and Performance‑Based Permitting: Frameworks like RCRA tiered permits 
 BIM Level 2 was a UK-defined benchmark for collaborative BIM working, focusing on federated models, shared information through a CDE, and defined data structures, originally based on the PAS 1192 standards.
 ISO 19650 is the international standard that has adopted, refined, and formalized the principles of BIM Level 2. It provides a globally recognized framework for managing information throughout the asset lifecycle using BIM. Complying with ISO 19650 is now the standard way to implement the processes and achieve the outcomes previously associated with BIM Level 2.
 
+
+## Validation Scripts
+
+Run `validate_repo.py` to execute repository validation steps, including JSON-LD checks for workflows.

--- a/validate_repo.py
+++ b/validate_repo.py
@@ -1,0 +1,25 @@
+"""Run all repository validation checks."""
+
+import os
+import subprocess
+import sys
+
+
+def main() -> None:
+    repo_dir = os.path.dirname(os.path.abspath(__file__))
+
+    schema_validator = os.path.join(
+        repo_dir, "open-data-layer", "schema", "validate_schema.py"
+    )
+    workflow_validator = os.path.join(repo_dir, "workflow", "validate_workflow.py")
+
+    for script in (schema_validator, workflow_validator):
+        if os.path.exists(script):
+            print(f"Running {script}...")
+            subprocess.run([sys.executable, script], check=True)
+        else:
+            print(f"Warning: {script} not found")
+
+
+if __name__ == "__main__":
+    main()

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -1,0 +1,20 @@
+# Workflow
+
+This directory contains example workflow definitions and utilities.
+
+## Validation
+
+Install the required dependency:
+
+```bash
+pip install pyld
+```
+
+To check that `workflow.jsonld` is valid JSON-LD, run:
+
+```bash
+python validate_workflow.py
+```
+
+You can also run the root `validate_repo.py` script to execute all repository
+validation steps at once.

--- a/workflow/validate_workflow.py
+++ b/workflow/validate_workflow.py
@@ -1,0 +1,23 @@
+"""Validate the workflow.jsonld file using the pyld library."""
+
+import json
+import sys
+from pyld import jsonld
+
+
+def validate(path="workflow.jsonld"):
+    """Load and validate the given JSON-LD file."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    # Attempt to expand the document. If it fails, pyld will raise an error.
+    jsonld.expand(data)
+
+
+if __name__ == "__main__":
+    try:
+        validate()
+    except Exception as exc:
+        print(f"Invalid JSON-LD: {exc}")
+        sys.exit(1)
+    else:
+        print("workflow.jsonld is valid JSON-LD")

--- a/workflow/workflow.jsonld
+++ b/workflow/workflow.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "name": "http://schema.org/name",
+    "step": "http://example.org/step"
+  },
+  "@id": "http://example.org/workflow/1",
+  "name": "Example Workflow",
+  "step": [{
+    "@id": "http://example.org/step/1",
+    "name": "Start"
+  }]
+}


### PR DESCRIPTION
## Summary
- create workflow validation script
- add repository validator to run schema and workflow checks
- document how to run workflow validation
- mention validation script in README

## Testing
- `python workflow/validate_workflow.py` *(fails: ModuleNotFoundError: No module named 'pyld')*
- `python validate_repo.py` *(fails: CalledProcessError: returned non-zero exit status 1)*