### PR TITLE
Add EPA permitting scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ https://subnational.doingbusiness.org/en/data/exploretopics/dealing-with-constru
 The basics:
 
 Interoperable Data Layer.
+- EPA Permitting schemas available in `openpermit/standards/epa-permitting`.
 
 Maintain state-of-the-art - maximal reliability, maximal security, standards-based-interoperability. 
 

--- a/agent/README.md
+++ b/agent/README.md
@@ -1,0 +1,5 @@
+# Importer Agents
+
+This directory contains scripts that convert external data formats into the OpenPermit Node Framework.
+
+- `epa_importer.py` – prototype importer for the EPA permitting XML format.

--- a/agent/epa_importer.py
+++ b/agent/epa_importer.py
@@ -1,0 +1,38 @@
+"""Minimal importer for EPA XML files.
+
+This script parses an EPA permit XML document and converts it to a set of OpenPermit node dictionaries compatible with the JSON-Schemas in `openpermit/standards/epa-permitting/schema`.
+
+The implementation is intentionally simple and should be expanded with full field mappings and error handling.
+"""
+
+import json
+import sys
+import xml.etree.ElementTree as ET
+
+def parse_xml(path):
+    tree = ET.parse(path)
+    root = tree.getroot()
+    permit_id = root.findtext("PermitIdentifier")
+    permit_name = root.findtext("PermitName")
+    return {
+        "identifier": permit_id,
+        "name": permit_name,
+        "epaTag": "PermitIdentification"
+    }
+
+def convert_to_nfl(data):
+    return {
+        "type": "permit.core",
+        "data": data
+    }
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: epa_importer.py <permit.xml>", file=sys.stderr)
+        sys.exit(1)
+    permit = parse_xml(sys.argv[1])
+    nfl_doc = convert_to_nfl(permit)
+    json.dump(nfl_doc, sys.stdout, indent=2)
+
+if __name__ == "__main__":
+    main()

--- a/openpermit/standards/epa-permitting/README.md
+++ b/openpermit/standards/epa-permitting/README.md
@@ -1,0 +1,26 @@
+# EPA Permitting Standard Mapping
+
+This folder contains draft JSON-Schema definitions that map the EPA Permitting Information Data Standard to the OpenPermit Node Framework (NFL).
+
+Each schema preserves the original EPA field names via the `epaTag` property to allow round‑tripping from XML.  These schemas are placeholders and will be expanded as the full data model is implemented.
+
+## Schemas
+
+- `permit.core.schema.json`
+- `feature.core.schema.json`
+- `permit.admin.schema.json`
+- `feature.metric.schema.json`
+- `methodology.core.schema.json`
+- `condition.core.schema.json`
+- `reporting.rule.schema.json`
+- `monitoring.rule.schema.json`
+
+## Conversion Example
+
+The example below illustrates a very simple transformation from EPA XML to NFL JSON using the importer script in `agent/epa_importer.py`.
+
+```bash
+python agent/epa_importer.py examples/sample_permit.xml > permit.json
+```
+
+The resulting JSON document conforms to the schemas in this directory.

--- a/openpermit/standards/epa-permitting/examples/sample_permit.xml
+++ b/openpermit/standards/epa-permitting/examples/sample_permit.xml
@@ -1,0 +1,5 @@
+<!-- Placeholder EPA permit XML -->
+<PermitIdentification>
+    <PermitIdentifier>TEST-123</PermitIdentifier>
+    <PermitName>Sample Permit</PermitName>
+</PermitIdentification>

--- a/openpermit/standards/epa-permitting/schema/condition.core.schema.json
+++ b/openpermit/standards/epa-permitting/schema/condition.core.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "condition.core",
+  "type": "object",
+  "properties": {
+    "requirement": {"type": "string"},
+    "quantity": {"type": "number"},
+    "unit": {"type": "string"},
+    "epaTag": {"type": "string"}
+  },
+  "required": ["requirement"]
+}

--- a/openpermit/standards/epa-permitting/schema/feature.core.schema.json
+++ b/openpermit/standards/epa-permitting/schema/feature.core.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "feature.core",
+  "type": "object",
+  "properties": {
+    "identifier": {"type": "string"},
+    "description": {"type": "string"},
+    "epaTag": {"type": "string"}
+  },
+  "required": ["identifier"]
+}

--- a/openpermit/standards/epa-permitting/schema/feature.metric.schema.json
+++ b/openpermit/standards/epa-permitting/schema/feature.metric.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "feature.metric",
+  "type": "object",
+  "properties": {
+    "metric": {"type": "string"},
+    "value": {"type": "number"},
+    "unit": {"type": "string"},
+    "epaTag": {"type": "string"}
+  },
+  "required": ["metric", "value"]
+}

--- a/openpermit/standards/epa-permitting/schema/methodology.core.schema.json
+++ b/openpermit/standards/epa-permitting/schema/methodology.core.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "methodology.core",
+  "type": "object",
+  "properties": {
+    "technology": {"type": "string"},
+    "description": {"type": "string"},
+    "epaTag": {"type": "string"}
+  },
+  "required": ["technology"]
+}

--- a/openpermit/standards/epa-permitting/schema/monitoring.rule.schema.json
+++ b/openpermit/standards/epa-permitting/schema/monitoring.rule.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "monitoring.rule",
+  "type": "object",
+  "properties": {
+    "siteDescription": {"type": "string"},
+    "frequency": {"type": "string"},
+    "method": {"type": "string"},
+    "epaTag": {"type": "string"}
+  },
+  "required": ["siteDescription"]
+}

--- a/openpermit/standards/epa-permitting/schema/permit.admin.schema.json
+++ b/openpermit/standards/epa-permitting/schema/permit.admin.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "permit.admin",
+  "type": "object",
+  "properties": {
+    "applicationCompleteDate": {"type": "string", "format": "date"},
+    "issueDate": {"type": "string", "format": "date"},
+    "effectiveDate": {"type": "string", "format": "date"},
+    "status": {"type": "string"},
+    "epaTag": {"type": "string"}
+  }
+}

--- a/openpermit/standards/epa-permitting/schema/permit.core.schema.json
+++ b/openpermit/standards/epa-permitting/schema/permit.core.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "permit.core",
+  "type": "object",
+  "properties": {
+    "identifier": {"type": "string"},
+    "name": {"type": "string"},
+    "program": {"type": "string"},
+    "type": {"type": "string"},
+    "epaTag": {"type": "string"}
+  },
+  "required": ["identifier", "name"]
+}

--- a/openpermit/standards/epa-permitting/schema/reporting.rule.schema.json
+++ b/openpermit/standards/epa-permitting/schema/reporting.rule.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "reporting.rule",
+  "type": "object",
+  "properties": {
+    "recipient": {"type": "string"},
+    "frequency": {"type": "string"},
+    "reportId": {"type": "string"},
+    "epaTag": {"type": "string"}
+  },
+  "required": ["recipient"]
+}


### PR DESCRIPTION
## Summary
- add placeholder schemas for EPA permitting standard
- include a sample importer script under `agent`
- document how to run the importer
- note the new schemas in the main README

## Testing
- `python3 -m py_compile agent/epa_importer.py`