### PR TITLE
Fix Spotsylvania permit schema JSON

### DIFF
--- a/Virginia/README.md
+++ b/Virginia/README.md
@@ -1,0 +1,6 @@
+# Spotsylvania Permit Schema
+
+This directory contains JSON-LD representations of permit data collected from Spotsylvania County, Virginia.
+
+- `spotsylvania.json` defines permit, document, and property types used by the county.
+- `spotsylvania_crosswalk.json` maps those property fields to equivalent terms in the Building and Land Development Specification (BLDS) so details are not lost when translating to other standards.

--- a/Virginia/spotsylvania.json
+++ b/Virginia/spotsylvania.json
@@ -429,4 +429,132 @@
     {
       "@id": "spotsylvania:BasementType",
       "@type": "PropertyType",
-      "dcterms:
+      "dcterms:title": "Basement Type",
+      "schema:domainIncludes": [
+        "spotsylvania:ResidentialPermit"
+      ],
+      "schema:rangeIncludes": "schema:Text"
+    },
+    {
+      "@id": "spotsylvania:FoundationType",
+      "@type": "PropertyType",
+      "dcterms:title": "Foundation Type",
+      "schema:domainIncludes": [
+        "spotsylvania:ResidentialPermit",
+        "spotsylvania:CommercialPermit"
+      ],
+      "schema:rangeIncludes": "schema:Text"
+    },
+    {
+      "@id": "spotsylvania:ExteriorWallType",
+      "@type": "PropertyType",
+      "dcterms:title": "Exterior Wall Type",
+      "schema:domainIncludes": [
+        "spotsylvania:ResidentialPermit",
+        "spotsylvania:CommercialPermit"
+      ],
+      "schema:rangeIncludes": "schema:Text"
+    },
+    {
+      "@id": "spotsylvania:RoofingType",
+      "@type": "PropertyType",
+      "dcterms:title": "Roofing Type",
+      "schema:domainIncludes": [
+        "spotsylvania:ResidentialPermit",
+        "spotsylvania:CommercialPermit"
+      ],
+      "schema:rangeIncludes": "schema:Text"
+    },
+    {
+      "@id": "spotsylvania:HeatingFuel",
+      "@type": "PropertyType",
+      "dcterms:title": "Heating Fuel",
+      "schema:domainIncludes": [
+        "spotsylvania:ResidentialPermit"
+      ],
+      "schema:rangeIncludes": "schema:Text"
+    },
+    {
+      "@id": "spotsylvania:AirConditioning",
+      "@type": "PropertyType",
+      "dcterms:title": "Air Conditioning",
+      "schema:domainIncludes": [
+        "spotsylvania:ResidentialPermit",
+        "spotsylvania:CommercialPermit"
+      ],
+      "schema:rangeIncludes": "schema:Boolean"
+    },
+    {
+      "@id": "spotsylvania:HomeOccupation",
+      "@type": "PropertyType",
+      "dcterms:title": "Home Occupation",
+      "schema:domainIncludes": [
+        "spotsylvania:ResidentialPermit"
+      ],
+      "schema:rangeIncludes": "schema:Boolean"
+    },
+    {
+      "@id": "spotsylvania:CurrentUse",
+      "@type": "PropertyType",
+      "dcterms:title": "Current Use",
+      "schema:domainIncludes": [
+        "spotsylvania:CommercialPermit"
+      ],
+      "schema:rangeIncludes": "schema:Text"
+    },
+    {
+      "@id": "spotsylvania:ProposedUse",
+      "@type": "PropertyType",
+      "dcterms:title": "Proposed Use",
+      "schema:domainIncludes": [
+        "spotsylvania:CommercialPermit"
+      ],
+      "schema:rangeIncludes": "schema:Text"
+    },
+    {
+      "@id": "spotsylvania:UseGroup",
+      "@type": "PropertyType",
+      "dcterms:title": "Use Group",
+      "schema:domainIncludes": [
+        "spotsylvania:CommercialPermit"
+      ],
+      "schema:rangeIncludes": "schema:Text"
+    },
+    {
+      "@id": "spotsylvania:ConstructionType",
+      "@type": "PropertyType",
+      "dcterms:title": "Construction Type",
+      "schema:domainIncludes": [
+        "spotsylvania:CommercialPermit"
+      ],
+      "schema:rangeIncludes": "schema:Text"
+    },
+    {
+      "@id": "spotsylvania:NumberOfFullBaths",
+      "@type": "PropertyType",
+      "dcterms:title": "Number of Full Baths",
+      "schema:domainIncludes": [
+        "spotsylvania:CommercialPermit"
+      ],
+      "schema:rangeIncludes": "schema:Integer"
+    },
+    {
+      "@id": "spotsylvania:NumberOfHalfBaths",
+      "@type": "PropertyType",
+      "dcterms:title": "Number of Half Baths",
+      "schema:domainIncludes": [
+        "spotsylvania:CommercialPermit"
+      ],
+      "schema:rangeIncludes": "schema:Integer"
+    },
+    {
+      "@id": "spotsylvania:FuelType",
+      "@type": "PropertyType",
+      "dcterms:title": "Fuel Type",
+      "schema:domainIncludes": [
+        "spotsylvania:CommercialPermit"
+      ],
+      "schema:rangeIncludes": "schema:Text"
+    }
+  ]
+}

--- a/Virginia/spotsylvania_crosswalk.json
+++ b/Virginia/spotsylvania_crosswalk.json
@@ -1,0 +1,37 @@
+{
+  "@context": {
+    "blds": "https://permitdata.org/ns#",
+    "spotsylvania": "https://www.spotsylvania.va.us/"
+  },
+  "@id": "spotsylvania:BLDSCrosswalk",
+  "@type": "schema:Dataset",
+  "schema:name": "Spotsylvania BLDS Crosswalk",
+  "mappings": {
+    "spotsylvania:PropertyAddress": "blds:PropertyAddress",
+    "spotsylvania:Subdivision": "blds:SubdivisionName",
+    "spotsylvania:GatedCommunity": "blds:IsGated",
+    "spotsylvania:GateCode": "blds:GateCode",
+    "spotsylvania:ProjectDescription": "blds:Description",
+    "spotsylvania:ProjectValue": "blds:EstimatedValue",
+    "spotsylvania:WaterSource": "blds:WaterService",
+    "spotsylvania:SewerSource": "blds:SewerService",
+    "spotsylvania:SquareFootage": "blds:BuildingArea",
+    "spotsylvania:NumberOfStories": "blds:NumberOfStories",
+    "spotsylvania:NumberOfBedrooms": "blds:NumberOfBedrooms",
+    "spotsylvania:NumberOfBathrooms": "blds:NumberOfBathrooms",
+    "spotsylvania:BasementType": "blds:BasementType",
+    "spotsylvania:FoundationType": "blds:FoundationType",
+    "spotsylvania:ExteriorWallType": "blds:ExteriorWallType",
+    "spotsylvania:RoofingType": "blds:RoofingType",
+    "spotsylvania:HeatingFuel": "blds:HeatingFuelType",
+    "spotsylvania:AirConditioning": "blds:HasAirConditioning",
+    "spotsylvania:HomeOccupation": "blds:HomeOccupation",
+    "spotsylvania:CurrentUse": "blds:CurrentUse",
+    "spotsylvania:ProposedUse": "blds:ProposedUse",
+    "spotsylvania:UseGroup": "blds:UseGroup",
+    "spotsylvania:ConstructionType": "blds:ConstructionType",
+    "spotsylvania:NumberOfFullBaths": "blds:NumberOfFullBaths",
+    "spotsylvania:NumberOfHalfBaths": "blds:NumberOfHalfBaths",
+    "spotsylvania:FuelType": "blds:FuelType"
+  }
+}

--- a/Virginia/spotsylvania_crosswalk.json
+++ b/Virginia/spotsylvania_crosswalk.json
@@ -1,7 +1,8 @@
 {
   "@context": {
     "blds": "https://permitdata.org/ns#",
-    "spotsylvania": "https://www.spotsylvania.va.us/"
+    "spotsylvania": "https://www.spotsylvania.va.us/",
+    "schema": "https://schema.org/"
   },
   "@id": "spotsylvania:BLDSCrosswalk",
   "@type": "schema:Dataset",


### PR DESCRIPTION
## Summary
- add a crosswalk file to map Spotsylvania fields to BLDS terms
- include README for the Virginia folder

## Testing
- `python3 - <<'PY'
import json
json.load(open('Virginia/spotsylvania.json'))
json.load(open('Virginia/spotsylvania_crosswalk.json'))
print('All JSON valid')
PY
`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a comprehensive README for the Spotsylvania Permit Schema, outlining available files and their purposes.
	- Expanded the Spotsylvania permitting schema with detailed property types for both residential and commercial permits, enabling more precise data representation.
	- Added a crosswalk file mapping Spotsylvania property attributes to standardized BLDS schema terms for improved data consistency and interoperability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->