### PR TITLE
Add working ontology example and docs

### DIFF
--- a/open-data-layer/docs/README.md
+++ b/open-data-layer/docs/README.md
@@ -1,3 +1,24 @@
 # Documentation
 
 This folder contains documentation related to the data layer.
+
+## Ontology usage
+
+The ontology files live in `../ontology`.  Run the generator script to (re)build
+`open_data_ontology.owl`:
+
+```bash
+python ../ontology/generate_ontology.py ../ontology/open_data_ontology.owl
+```
+
+The resulting Turtle file defines a small set of classes and properties that can
+be queried using SPARQL.  Example queries are available in
+`../ontology/queries.sparql`.
+
+Any SPARQL engine capable of reading Turtle may be used to run the queries, for
+example `rdfpipe` from rdflib:
+
+```bash
+rdfpipe --input-format turtle ../ontology/open_data_ontology.owl \
+    --query ../ontology/queries.sparql
+```

--- a/open-data-layer/ontology/generate_ontology.py
+++ b/open-data-layer/ontology/generate_ontology.py
@@ -1,4 +1,63 @@
-"""Placeholder script for ontology generation."""
+"""Generate a small example ontology in Turtle format.
+
+The ontology is defined using simple Python data structures.  Running this script
+will create ``open_data_ontology.owl`` in the same directory.
+"""
+
+from pathlib import Path
+
+# Basic class and property definitions used to build the ontology
+CLASSES = {
+    "Permit": "A permit record.",
+    "Applicant": "An applicant for a permit.",
+}
+
+PROPERTIES = [
+    {
+        "name": "hasApplicant",
+        "domain": "Permit",
+        "range": "Applicant",
+        "comment": "Links a permit to its applicant.",
+    }
+]
+
+PREFIXES = """@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix : <http://open-permit.org/ontology/> .
+"""
+
+
+def build_ontology() -> str:
+    """Return the ontology as a Turtle string."""
+    lines = [PREFIXES]
+    for name, comment in CLASSES.items():
+        lines.extend([
+            f":{name} a owl:Class ;",
+            f"    rdfs:label \"{name}\" ;",
+            f"    rdfs:comment \"{comment}\" .",
+            "",
+        ])
+    for prop in PROPERTIES:
+        lines.extend([
+            f":{prop['name']} a owl:ObjectProperty ;",
+            f"    rdfs:domain :{prop['domain']} ;",
+            f"    rdfs:range :{prop['range']} ;",
+            f"    rdfs:label \"{prop['name'].replace('_', ' ')}\" ;",
+            f"    rdfs:comment \"{prop['comment']}\" .",
+            "",
+        ])
+    return "\n".join(lines)
+
+
+def main(output: str = "open_data_ontology.owl") -> None:
+    """Write the ontology to ``output``."""
+    text = build_ontology()
+    Path(output).write_text(text, encoding="utf-8")
+    print(f"Wrote ontology to {output}")
+
 
 if __name__ == "__main__":
-    print("Generate ontology here")
+    import sys
+    target = sys.argv[1] if len(sys.argv) > 1 else "open_data_ontology.owl"
+    main(target)

--- a/open-data-layer/ontology/open_data_ontology.owl
+++ b/open-data-layer/ontology/open_data_ontology.owl
@@ -1,1 +1,18 @@
-<!-- Placeholder ontology -->
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix : <http://open-permit.org/ontology/> .
+
+:Permit a owl:Class ;
+    rdfs:label "Permit" ;
+    rdfs:comment "A permit record." .
+
+:Applicant a owl:Class ;
+    rdfs:label "Applicant" ;
+    rdfs:comment "An applicant for a permit." .
+
+:hasApplicant a owl:ObjectProperty ;
+    rdfs:domain :Permit ;
+    rdfs:range :Applicant ;
+    rdfs:label "hasApplicant" ;
+    rdfs:comment "Links a permit to its applicant." .

--- a/open-data-layer/ontology/queries.sparql
+++ b/open-data-layer/ontology/queries.sparql
@@ -1,1 +1,19 @@
-# SPARQL queries placeholder
+# Example SPARQL queries for the OpenPermit ontology
+PREFIX : <http://open-permit.org/ontology/>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+
+# List all classes defined in the ontology
+SELECT ?class WHERE {
+    ?class a owl:Class .
+}
+
+# List all object properties
+SELECT ?property WHERE {
+    ?property a owl:ObjectProperty .
+}
+
+# Retrieve permits and their applicants (requires data graph)
+SELECT ?permit ?applicant WHERE {
+    ?permit a :Permit .
+    ?permit :hasApplicant ?applicant .
+}


### PR DESCRIPTION
## Summary
- add a tiny ontology generator and example ontology
- provide sample SPARQL queries
- document how to use the generator and queries

## Testing
- `python open-data-layer/ontology/generate_ontology.py open-data-layer/ontology/open_data_ontology.owl`