### PR TITLE
Add open data layer samples

### DIFF
--- a/open-data-layer/README.md
+++ b/open-data-layer/README.md
@@ -1,8 +1,6 @@
 # Open Data Layer
 
-This directory contains reference materials and sample files for the OpenPermit data layer.
-It mirrors the structure described in the project documentation.  Each subfolder
-contains placeholder content that can be replaced with real implementations.
+This directory holds small examples that demonstrate how a permit system can be structured. Each subfolder contains sample data or helper scripts.
 
 ```
 ├── schema/
@@ -21,7 +19,28 @@ contains placeholder content that can be replaced with real implementations.
 │   ├── README.md
 │   ├── standards.md
 │   └── odata_edm.xml
-├── .gitignore
-├── LICENSE
-└── README.md
 ```
+
+## File descriptions
+
+### schema/
+- **blds.json** – Minimal BLDS permit example.
+- **ifc.json** – Snippet of an IFC model.
+- **iso20022.json** – Example payment message.
+- **geojson.json** – GeoJSON feature for location data.
+- **sample_data.jsonld** – JSON‑LD sample referencing the ontology.
+- **validation.shacl** – SHACL shapes for RDF validation (placeholder).
+- **validate_schema.py** – Script to validate the JSON samples above.
+
+### ontology/
+- **open_data_ontology.owl** – OWL ontology defining `Permit`, `Applicant` and their relationship.
+- **queries.sparql** – Example SPARQL queries used during development.
+- **generate_ontology.py** – Regenerates `open_data_ontology.owl`.
+
+### docs/
+Documentation and standards notes related to the data layer.
+
+## Regeneration and validation
+- Run `python ontology/generate_ontology.py` to recreate the example ontology.
+- Validate the JSON examples with `python schema/validate_schema.py`. The command prints whether each file conforms to its minimal schema.
+- `validation.shacl` can be used with any SHACL engine to validate `sample_data.jsonld` against RDF shapes.

--- a/open-data-layer/ontology/generate_ontology.py
+++ b/open-data-layer/ontology/generate_ontology.py
@@ -1,4 +1,32 @@
-"""Placeholder script for ontology generation."""
+"""Generate a minimal OWL ontology used by the sample data."""
+
+import os
+
+ONTOLOGY = """<?xml version=\"1.0\"?>
+<rdf:RDF xmlns=\"http://example.org/ontology#\"
+     xml:base=\"http://example.org/ontology\"
+     xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"
+     xmlns:owl=\"http://www.w3.org/2002/07/owl#\"
+     xmlns:rdfs=\"http://www.w3.org/2000/01/rdf-schema#\"
+     xmlns:xsd=\"http://www.w3.org/2001/XMLSchema#\">
+    <owl:Ontology rdf:about=\"http://example.org/ontology\"/>
+
+    <owl:Class rdf:about=\"#Permit\"/>
+    <owl:Class rdf:about=\"#Applicant\"/>
+
+    <owl:ObjectProperty rdf:about=\"#applicant\">
+        <rdfs:domain rdf:resource=\"#Permit\"/>
+        <rdfs:range rdf:resource=\"#Applicant\"/>
+    </owl:ObjectProperty>
+</rdf:RDF>
+"""
+
+def main():
+    output_path = os.path.join(os.path.dirname(__file__), "open_data_ontology.owl")
+    with open(output_path, "w") as f:
+        f.write(ONTOLOGY)
+    print(f"Ontology written to {output_path}")
+
 
 if __name__ == "__main__":
-    print("Generate ontology here")
+    main()

--- a/open-data-layer/ontology/open_data_ontology.owl
+++ b/open-data-layer/ontology/open_data_ontology.owl
@@ -1,1 +1,17 @@
-<!-- Placeholder ontology -->
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://example.org/ontology#"
+     xml:base="http://example.org/ontology"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+    <owl:Ontology rdf:about="http://example.org/ontology"/>
+
+    <owl:Class rdf:about="#Permit"/>
+    <owl:Class rdf:about="#Applicant"/>
+
+    <owl:ObjectProperty rdf:about="#applicant">
+        <rdfs:domain rdf:resource="#Permit"/>
+        <rdfs:range rdf:resource="#Applicant"/>
+    </owl:ObjectProperty>
+</rdf:RDF>

--- a/open-data-layer/schema/sample_data.jsonld
+++ b/open-data-layer/schema/sample_data.jsonld
@@ -1,1 +1,18 @@
-{}
+{
+  "@context": {
+    "name": "http://schema.org/name",
+    "issued": "http://schema.org/dateIssued",
+    "Applicant": "http://example.org/ontology#Applicant",
+    "Permit": "http://example.org/ontology#Permit",
+    "applicant": {"@id": "http://example.org/ontology#applicant", "@type": "@id"}
+  },
+  "@id": "http://example.org/permit/1234",
+  "@type": "Permit",
+  "name": "Example Building Permit",
+  "issued": "2024-05-01",
+  "applicant": {
+    "@id": "http://example.org/applicant/A1",
+    "@type": "Applicant",
+    "name": "Jane Doe"
+  }
+}


### PR DESCRIPTION
## Summary
- add sample JSON-LD data
- populate OWL ontology and generator script
- document how to regenerate/validate samples

## Testing
- `python open-data-layer/ontology/generate_ontology.py`
- `python open-data-layer/schema/validate_schema.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a minimal OWL ontology defining "Permit" and "Applicant" classes and their relationship.
  - Added a sample JSON-LD file representing a building permit with linked applicant data.

- **Documentation**
  - Enhanced the README with detailed explanations of directory contents, file purposes, and instructions for ontology regeneration and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->