### PR TITLE
Fix CI badge markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Please comment/contribute/share/join!
 - [Interoperable Data Layer](#interoperable-data-layer)
 - [References](#references)
 - [Security](#security)
-
+![CI](https://github.com/builtbycorelot/OpenPermit/actions/workflows/ci.yml/badge.svg)
 Why this matters:
 
 https://subnational.doingbusiness.org/en/data/exploretopics/dealing-with-construction-permits/why-matters


### PR DESCRIPTION
## Summary
- correct CI badge formatting in README

## Testing
- `git status --short`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a continuous integration (CI) status badge to the README file to display the current build status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->