### PR TITLE
fix: enforce object in setAIParameters

### DIFF
--- a/src/core/node.js
+++ b/src/core/node.js
@@ -120,11 +120,15 @@ class Node {
 
   /**
    * Set or merge AI parameters on the node
-   * @param {Object} parameters - AI parameters
+   * @param {Object} parameters - AI parameters. Must be a plain object
    * @returns {Node} - The node instance for chaining
    */
   setAIParameters(parameters = {}) {
-    if (typeof parameters !== 'object' || parameters === null) {
+    if (
+      typeof parameters !== 'object' ||
+      parameters === null ||
+      Array.isArray(parameters)
+    ) {
       return this;
     }
 


### PR DESCRIPTION
## Summary
- prevent accidental array merging in `Node.setAIParameters`
- document requirement for a plain object

## Testing
- `node -e "const {Node}=require('./src/core/node.js'); let n=new Node('id','type'); n.setAIParameters([1,2]); console.log(n.aiInterface.parameters);"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for AI parameter settings to ensure only plain objects are accepted, preventing arrays or invalid types from being used.

- **Documentation**
  - Updated help text to clarify that AI parameters must be provided as plain objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->