### PR TITLE
Add NIEM-Releases submodule setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ The basics:
 
 ## Interoperable Data Layer
 - EPA Permitting schemas available in `openpermit/standards/epa-permitting`.
-- Generate NIEM 6.0 JSON Schemas with `python scripts/niem6_build_schemas.py`.
+- Initialize NIEM sources with `bash scripts/setup_niem_releases.sh` then generate NIEM 6.0 JSON Schemas with `python scripts/niem6_build_schemas.py`.
 
 ### Building NIEM Schemas
-Run `python scripts/niem6_build_schemas.py` to generate stub JSON Schema files under `openpermit/schema/niem/6.0/`.
+First run `bash scripts/setup_niem_releases.sh` to clone the NIEM-Releases submodule. Then run `python scripts/niem6_build_schemas.py` to generate stub JSON Schema files under `openpermit/schema/niem/6.0/`.
 
 
 A high-level architecture diagram is available in

--- a/openpermit/standards/niem/README.md
+++ b/openpermit/standards/niem/README.md
@@ -1,3 +1,19 @@
 # NIEM Standard
 
-This folder is intended to hold the [NIEM-Releases](https://github.com/NIEM/NIEM-Releases) repository as a Git submodule pinned to tag `6.0`. Due to the sandbox environment, the submodule could not be initialized. Clone the repository and check out tag `6.0` into `openpermit/standards/niem/NIEM-Releases` before running the schema build script.
+This folder should contain the [NIEM-Releases](https://github.com/NIEM/NIEM-Releases) repository pinned to tag `6.0`.
+
+Run the helper script below from the repository root to clone the submodule:
+
+```sh
+bash scripts/setup_niem_releases.sh
+```
+
+The script executes the equivalent of:
+
+```sh
+git submodule add https://github.com/NIEM/NIEM-Releases openpermit/standards/niem/NIEM-Releases
+cd openpermit/standards/niem/NIEM-Releases
+git checkout tags/6.0
+```
+
+Make sure the submodule exists before running the schema build script.

--- a/scripts/setup_niem_releases.sh
+++ b/scripts/setup_niem_releases.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Initialize the NIEM-Releases submodule at tag 6.0
+# Usage: bash scripts/setup_niem_releases.sh
+set -e
+
+REPO_PATH="openpermit/standards/niem/NIEM-Releases"
+
+if [ -d "$REPO_PATH" ]; then
+    echo "NIEM-Releases already exists at $REPO_PATH"
+    exit 0
+fi
+
+# Add the submodule
+git submodule add https://github.com/NIEM/NIEM-Releases "$REPO_PATH"
+cd "$REPO_PATH"
+# Checkout the 6.0 tag
+git checkout tags/6.0
+cd - >/dev/null
+
+echo "NIEM-Releases cloned to $REPO_PATH at tag 6.0"


### PR DESCRIPTION
## Summary
- add `scripts/setup_niem_releases.sh` to fetch NIEM-Releases at tag 6.0
- document submodule setup in `openpermit/standards/niem/README.md`
- mention the new setup step in the main README so schema generation works

## Testing
- `python -m py_compile scripts/niem6_build_schemas.py`