### PR TITLE
Add Python and JS tests

### DIFF
--- a/helpers/compat-worker.js
+++ b/helpers/compat-worker.js
@@ -1,0 +1,24 @@
+const { Worker: NodeWorker } = require('node:worker_threads');
+
+class CompatWorker extends NodeWorker {
+  constructor(filename, options) {
+    super(filename, options);
+    this._listeners = new Map();
+  }
+
+  addEventListener(event, listener) {
+    const wrapper = (data) => listener({ data });
+    this._listeners.set(listener, wrapper);
+    this.on(event, wrapper);
+  }
+
+  removeEventListener(event, listener) {
+    const wrapper = this._listeners.get(listener);
+    if (wrapper) {
+      this.off(event, wrapper);
+      this._listeners.delete(listener);
+    }
+  }
+}
+
+module.exports = CompatWorker;

--- a/helpers/worker.js
+++ b/helpers/worker.js
@@ -1,0 +1,50 @@
+const { parentPort } = require('node:worker_threads');
+const { Node } = require('../src/core/node.js');
+
+async function validateNode(node) {
+  const nodeInstance = node instanceof Node ? node : Node.fromJSON(node);
+  const results = {
+    valid: true,
+    errors: [],
+    warnings: [],
+    info: []
+  };
+
+  if (!nodeInstance.id) {
+    results.valid = false;
+    results.errors.push({ code: 'MISSING_ID', message: 'Node ID is required' });
+  }
+  if (!nodeInstance.type) {
+    results.valid = false;
+    results.errors.push({ code: 'MISSING_TYPE', message: 'Node type is required' });
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  return results;
+}
+
+parentPort.on('message', async ({ callbackId, action, payload }) => {
+  try {
+    switch (action) {
+      case 'CREATE_NODE': {
+        const node = new Node(payload.id, payload.type, payload.metadata);
+        if (payload.attributes) {
+          Object.entries(payload.attributes).forEach(([k, v]) => node.addAttribute(k, v));
+        }
+        parentPort.postMessage({ callbackId, success: true, node: node.toJSON() });
+        break;
+      }
+      case 'VALIDATE_NODE': {
+        const results = await validateNode(payload.node);
+        parentPort.postMessage({ callbackId, success: true, results });
+        break;
+      }
+      default:
+        throw new Error(`Unknown action: ${action}`);
+    }
+  } catch (err) {
+    parentPort.postMessage({ callbackId, success: false, error: err.message });
+  }
+});
+
+parentPort.postMessage({ type: 'READY' });

--- a/open-data-layer/README.md
+++ b/open-data-layer/README.md
@@ -36,3 +36,11 @@ coverage. Install it with:
 ```
 pip install jsonschema
 ```
+
+### Testing
+
+Run the Python unit tests with [pytest](https://pytest.org/):
+
+```bash
+pytest
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "openpermit",
+  "version": "0.1.0",
+  "scripts": {
+    "test": "node --test test/apiClient.test.js"
+  }
+}

--- a/src/README.md
+++ b/src/README.md
@@ -97,6 +97,14 @@ example/
 npm run build
 ```
 
+### Running Tests
+
+Execute the JavaScript unit tests with:
+
+```bash
+npm test
+```
+
 ## Contributing
 
 Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/test/apiClient.test.js
+++ b/test/apiClient.test.js
@@ -1,0 +1,16 @@
+const { test } = require('node:test');
+const { strictEqual, ok } = require('node:assert');
+const path = require('node:path');
+const { OpenPermit } = require('../src/api/index.js');
+const CompatWorker = require('../helpers/compat-worker');
+
+global.Worker = CompatWorker;
+
+test('create and validate node via worker', async () => {
+  const client = new OpenPermit({ workerPath: path.join(__dirname, '../helpers/worker.js') });
+  const node = await client.createNode({ id: 'n1', type: 'RequirementNode' });
+  strictEqual(node['@id'], 'n1');
+  const results = await client.validateNode(node);
+  ok(results.valid);
+  await client.worker.terminate();
+});

--- a/tests/test_generate_ontology.py
+++ b/tests/test_generate_ontology.py
@@ -1,0 +1,17 @@
+import importlib.util
+from pathlib import Path
+
+# Load the generate_ontology module from its file path
+module_path = Path(__file__).resolve().parents[1] / 'open-data-layer' / 'ontology' / 'generate_ontology.py'
+spec = importlib.util.spec_from_file_location('generate_ontology', module_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+build_ontology = module.build_ontology
+
+
+def test_build_ontology_contains_expected_terms():
+    text = build_ontology()
+    assert ':Permit a owl:Class ;' in text
+    assert ':Applicant a owl:Class ;' in text
+    assert ':hasApplicant a owl:ObjectProperty ;' in text


### PR DESCRIPTION
## Summary
- add `pytest` test for ontology generation
- add Node tests using the built-in test runner and helper worker
- update docs and package.json to run tests via `npm test` or `pytest`

## Testing
- `npm test --silent`
- `python3 -m pytest -q` *(fails: No module named pytest)*