### PR TITLE
Add coverage integration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,7 @@
+codecov:
+  require_ci_to_pass: yes
+coverage:
+  precision: 2
+  round: down
+  range: '70..100'
+comment: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install Python deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest coverage
+      - name: Run Python tests with coverage
+        run: |
+          coverage run -m pytest
+          coverage xml
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Run Node tests
+        run: npm test
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml
+

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![CI](https://github.com/builtbycorelot/OpenPermit/actions/workflows/ci.yml/badge.svg)](./.github/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/builtbycorelot/OpenPermit/branch/main/graph/badge.svg)](https://codecov.io/gh/builtbycorelot/OpenPermit)
+[![Docs](https://img.shields.io/badge/docs-website-blue.svg)](https://builtbycorelot.github.io/OpenPermit)
 
 **Public demo →** <https://builtbycorelot.github.io/OpenPermit>
 


### PR DESCRIPTION
## Summary
- integrate Codecov coverage service
- run tests & coverage in CI
- show coverage and documentation badges in README

## Testing
- `npm test --silent`
- `pytest -q` *(fails: command not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a continuous integration workflow to automatically run Python and Node.js tests and upload coverage reports.
  - Introduced a configuration to customize code coverage reporting behavior.
- **Documentation**
  - Updated the README with badges for code coverage and documentation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->