### PR TITLE
Add Jest configs and tests

### DIFF
--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/test/integration/**/*.test.js']
+};

--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/test/unit/**/*.test.js']
+};

--- a/test/integration/openpermit.test.js
+++ b/test/integration/openpermit.test.js
@@ -1,0 +1,18 @@
+const path = require('path');
+const { OpenPermit } = require('../../src/api/index.js');
+const CompatWorker = require('../../helpers/compat-worker');
+
+global.Worker = CompatWorker;
+
+describe('OpenPermit with worker', () => {
+  test('create and validate node', async () => {
+    const client = new OpenPermit({ workerPath: path.join(__dirname, '../../helpers/worker.js') });
+    const node = await client.createNode({ id: 'n1', type: 'RequirementNode', attributes: { foo: 'bar' } });
+    expect(node['@id']).toBe('n1');
+    expect(node.attributes.foo).toBe('bar');
+
+    const results = await client.validateNode(node);
+    expect(results.valid).toBe(true);
+    await client.worker.terminate();
+  });
+});

--- a/test/integration/openpermit.test.js
+++ b/test/integration/openpermit.test.js
@@ -5,14 +5,24 @@ const CompatWorker = require('../../helpers/compat-worker');
 global.Worker = CompatWorker;
 
 describe('OpenPermit with worker', () => {
+  let client;
+
+  beforeEach(() => {
+    client = new OpenPermit({ workerPath: path.join(__dirname, '../../helpers/worker.js') });
+  });
+
+  afterEach(async () => {
+    if (client && client.worker) {
+      await client.worker.terminate();
+    }
+  });
+
   test('create and validate node', async () => {
-    const client = new OpenPermit({ workerPath: path.join(__dirname, '../../helpers/worker.js') });
     const node = await client.createNode({ id: 'n1', type: 'RequirementNode', attributes: { foo: 'bar' } });
     expect(node['@id']).toBe('n1');
     expect(node.attributes.foo).toBe('bar');
 
     const results = await client.validateNode(node);
     expect(results.valid).toBe(true);
-    await client.worker.terminate();
   });
 });

--- a/test/unit/node.test.js
+++ b/test/unit/node.test.js
@@ -1,0 +1,34 @@
+const { Node } = require('../../src/core/node.js');
+
+describe('Node attributes and relationships', () => {
+  test('addAttribute sets value and updates modified timestamp', () => {
+    const node = new Node('n1', 'Test');
+    const originalModified = node.metadata.modified;
+    node.addAttribute('foo', 'bar');
+    expect(node.attributes.foo).toBe('bar');
+    expect(node.metadata.modified).not.toBe(originalModified);
+  });
+
+  test('addRelationship validates input and prevents duplicates', () => {
+    const node = new Node('n1', 'Test');
+    expect(() => node.addRelationship('', 't1')).toThrow();
+    expect(() => node.addRelationship('child', '')).toThrow();
+    node.addRelationship('child', 't1');
+    expect(node.relationships.length).toBe(1);
+    // duplicate should be ignored
+    node.addRelationship('child', 't1');
+    expect(node.relationships.length).toBe(1);
+  });
+
+  test('fromJSON restores attributes and relationships', () => {
+    const orig = new Node('n1', 'Test');
+    orig.addAttribute('a', 1);
+    orig.addRelationship('rel', 'n2', { extra: true });
+    const json = orig.toJSON();
+    const restored = Node.fromJSON(json);
+    expect(restored.attributes.a).toBe(1);
+    expect(restored.relationships.length).toBe(1);
+    expect(restored.relationships[0].type).toBe('rel');
+    expect(restored.relationships[0].target).toBe('n2');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest unit and integration configs
- test Node attribute/relationship functionality
- integration test for OpenPermit client with worker

## Testing
- `npm test`
- `npx jest -c jest.unit.config.js` *(fails: command not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Added new integration tests to verify API functionality with worker processes.
	- Introduced unit tests for node attribute management, relationship handling, and JSON serialization/deserialization.
	- Added separate configuration files to streamline running unit and integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->