### PR TITLE
Add basic CI workflow and badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install ESLint
+        run: npm install eslint
+      - name: Run ESLint
+        run: npx eslint .
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm install
+      - name: Run unit tests with coverage
+        run: NODE_V8_COVERAGE=coverage npm test
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          directory: coverage
+          fail_ci_if_error: true
+          flags: unittests
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    needs: unit-tests
+    steps:
+      - uses: actions/checkout@v3
+      - name: Integration tests
+        run: echo "No integration tests defined"
+
+  e2e-tests:
+    runs-on: ubuntu-latest
+    needs: integration-tests
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm install
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+      - name: Run Playwright tests
+        run: npx playwright test
+      - uses: actions/upload-artifact@v3
+        with:
+          name: playwright-report
+          path: playwright-report

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 > *Permitting distilled for **simplicity, speed & interoperability***
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![CI](https://github.com/builtbycorelot/OpenPermit/actions/workflows/ci.yml/badge.svg)](./.github/workflows/ci.yml)
+[![Build Status](https://github.com/builtbycorelot/OpenPermit/actions/workflows/ci.yml/badge.svg)](https://github.com/builtbycorelot/OpenPermit/actions/workflows/ci.yml)
 
 **Public demo →** <https://builtbycorelot.github.io/OpenPermit>
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow with lint/unit/integration/e2e jobs
- publish coverage to Codecov
- show CI badge in README

## Testing
- `node --test test/apiClient.test.js`
- `python3 -m pytest -q` *(fails: No module named pytest)*