### PR TITLE
Add requirements.txt and update install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ OpenPermit is an **open-source data layer and toolkit** that modernises construc
 ```bash
 git clone https://github.com/builtbycorelot/OpenPermit.git
 cd OpenPermit
-pip install -r requirements-dev.txt
+pip install -r requirements.txt
 pytest                                 # run unit tests
 python scripts/niem6_build_schemas.py  # generate NIEM-6.0 JSON Schemas
 python workflow/validate_workflow.py   # sample workflow validation

--- a/open-data-layer/README.md
+++ b/open-data-layer/README.md
@@ -31,10 +31,10 @@ contains placeholder content that can be replaced with real implementations.
 Use `validate_schema.py` to check the example JSON files. The script falls back
 to a minimal validator if the [`jsonschema`](https://pypi.org/project/jsonschema/)
 package is missing, but installing the real library provides much more complete
-coverage. Install it with:
+coverage. Install dependencies from the repository root with:
 
 ```
-pip install jsonschema
+pip install -r ../requirements.txt
 ```
 
 ### Testing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+jsonschema


### PR DESCRIPTION
## Summary
- add requirements.txt listing `jsonschema`
- update the root README quick-start steps
- update open-data-layer README installation instructions

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*