### PR TITLE
Fix README stray separator lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![CI](https://github.com/builtbycorelot/OpenPermit/actions/workflows/ci.yml/badge.svg)](./.github/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/builtbycorelot/OpenPermit/branch/main/graph/badge.svg)](https://codecov.io/gh/builtbycorelot/OpenPermit)
 [![Docs](https://img.shields.io/badge/docs-website-blue.svg)](https://builtbycorelot.github.io/OpenPermit)
-=======
 [![Build Status](https://github.com/builtbycorelot/OpenPermit/actions/workflows/ci.yml/badge.svg)](https://github.com/builtbycorelot/OpenPermit/actions/workflows/ci.yml)
 
 **Public demo →** <https://builtbycorelot.github.io/OpenPermit>
@@ -43,7 +42,6 @@ git clone https://github.com/builtbycorelot/OpenPermit.git
 cd OpenPermit
 npm install                             # install JS dependencies
 npm test                                # run unit tests
-=======
 pip install -r requirements.txt
 pytest                                 # run unit tests
 python scripts/niem6_build_schemas.py  # generate NIEM-6.0 JSON Schemas


### PR DESCRIPTION
## Summary
- remove leftover `=======` separator lines

## Testing
- `npm test` *(fails: Invalid package.json)*
- `pip install -r requirements.txt` *(fails: Could not fetch packages)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed extraneous separator lines from the README for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->