### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,32 +6,6 @@ on:
   pull_request:
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-      - name: Install Python deps
-        run: |
-          python -m pip install --upgrade pip
-          pip install pytest coverage
-      - name: Run Python tests with coverage
-        run: |
-          coverage run -m pytest
-          coverage xml
-      - name: Set up Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: '20'
-      - name: Run Node tests
-        run: npm test
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          files: coverage.xml
 
   lint:
     runs-on: ubuntu-latest
@@ -64,17 +38,9 @@ jobs:
           fail_ci_if_error: true
           flags: unittests
 
-  integration-tests:
-    runs-on: ubuntu-latest
-    needs: unit-tests
-    steps:
-      - uses: actions/checkout@v3
-      - name: Integration tests
-        run: echo "No integration tests defined"
-
   e2e-tests:
     runs-on: ubuntu-latest
-    needs: integration-tests
+    needs: unit-tests
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
## Summary
- simplify CI workflow to only run lint, unit and e2e tests

## Testing
- `npm test`
- `npx playwright test` *(fails: browsers not installed)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow to remove redundant test jobs and streamline end-to-end test dependencies. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->