### PR TITLE
Add workflow validation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npm run serve
 pip install -r requirements.txt
 pytest                                 # run unit tests
 python scripts/niem6_build_schemas.py  # generate NIEM-6.0 JSON Schemas
-python workflow/validate_workflow.py   # sample workflow validation
+python workflow/validate_workflow.py   # validate workflow JSON-LD
 npx playwright install                # install browsers for E2E tests
 npx playwright test                   # run E2E suite
 

--- a/workflow/validate_workflow.py
+++ b/workflow/validate_workflow.py
@@ -1,0 +1,37 @@
+"""Basic validator for workflow.jsonld."""
+
+import json
+import os
+import sys
+
+WORKFLOW_FILE = os.path.join(os.path.dirname(__file__), "workflow.jsonld")
+
+
+def main() -> int:
+    try:
+        with open(WORKFLOW_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception as exc:  # file missing or invalid JSON
+        print(f"Error loading {WORKFLOW_FILE}: {exc}")
+        return 1
+
+    errors = []
+    if "@id" not in data:
+        errors.append("missing @id")
+    if "schema:itemListElement" not in data:
+        errors.append("missing schema:itemListElement")
+    else:
+        item_list = data["schema:itemListElement"]
+        if not isinstance(item_list, list) or not item_list:
+            errors.append("schema:itemListElement should be a non-empty list")
+
+    if errors:
+        print("workflow.jsonld INVALID:", "; ".join(errors))
+        return 2
+
+    print("workflow.jsonld VALID: contains @id and schema:itemListElement list")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- provide a Python script to check workflow.jsonld
- document workflow validation step in the quick-start guide

## Testing
- `npm test`
- `npm run lint`
- `pytest`
- `python workflow/validate_workflow.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a script to validate the structure and content of workflow JSON-LD files, providing clear error messages for missing or invalid fields.
- **Documentation**
  - Updated the README to clarify the validation script's purpose in the quick-start instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->