### PR TITLE
Remove stale pre-commit instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ See [`SECURITY.md`](SECURITY.md) for threat model, disclosure policy & NIST cont
 PRs welcome!  
 1. Follow the guidelines in [`CONTRIBUTING.md`](CONTRIBUTING.md)  
 2. Open an issue or discussion for larger features  
-3. Run `pre-commit install` to auto-format code & docs
 
 ---
 


### PR DESCRIPTION
## Summary
- delete reference to pre-commit because repository lacks a config

## Testing
- `git status --short`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the "Contributing" section in the README to remove the instruction about running `pre-commit install`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->