### PR TITLE
Update EPA example path

### DIFF
--- a/openpermit/standards/epa-permitting/README.md
+++ b/openpermit/standards/epa-permitting/README.md
@@ -19,8 +19,11 @@ Each schema preserves the original EPA field names via the `epaTag` property to 
 
 The example below illustrates a very simple transformation from EPA XML to NFL JSON using the importer script in `agent/epa_importer.py`.
 
+Run the command below from the repository root to transform the included sample
+permit:
+
 ```bash
-python agent/epa_importer.py examples/sample_permit.xml > permit.json
+python agent/epa_importer.py openpermit/standards/epa-permitting/examples/sample_permit.xml > permit.json
 ```
 
 The resulting JSON document conforms to the schemas in this directory.


### PR DESCRIPTION
## Summary
- clarify how to run EPA XML conversion example from repo root

## Testing
- `python agent/epa_importer.py openpermit/standards/epa-permitting/examples/sample_permit.xml > /tmp/permit.json && head /tmp/permit.json`