### PR TITLE
Enable Playwright in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,15 @@ pip install -r requirements.txt
 pytest                                 # run unit tests
 python scripts/niem6_build_schemas.py  # generate NIEM-6.0 JSON Schemas
 python workflow/validate_workflow.py   # sample workflow validation
-npx playwright install                # install browsers for E2E tests
+npx playwright install --with-deps    # install browsers & dependencies for E2E tests
 npx playwright test                   # run E2E suite
 
 
 
 ```
+
+When running in CI, be sure to execute `npx playwright install --with-deps` so that
+all system dependencies for the browsers are installed.
 
 The helper scripts rely on Python packages listed in
 [`requirements.txt`](requirements.txt). Install them with the `pip` command

--- a/test/e2e/demo.spec.js
+++ b/test/e2e/demo.spec.js
@@ -1,4 +1,10 @@
 const { test } = require('node:test');
 
+const { test, expect } = require('@playwright/test');
+
 // Simple placeholder test to ensure Playwright can run in CI
-test('E2E tests require Playwright', () => {});
+test('E2E tests require Playwright', async ({ page }) => {
+  // Minimal test to verify Playwright is working
+  await page.goto('data:text/html,<h1>Test</h1>');
+  await expect(page.locator('h1')).toHaveText('Test');
+});

--- a/test/e2e/demo.spec.js
+++ b/test/e2e/demo.spec.js
@@ -1,4 +1,4 @@
 const { test } = require('node:test');
 
-// Playwright is not available in the offline test environment, so skip these tests
-test.skip('E2E tests require Playwright', () => {});
+// Simple placeholder test to ensure Playwright can run in CI
+test('E2E tests require Playwright', () => {});


### PR DESCRIPTION
## Summary
- document Playwright install with dependencies
- activate placeholder E2E test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683a891a6dd88333a4ed99a9cbae92b5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Quick-start guide to clarify Playwright installation with required system dependencies and added guidance for CI environments.

- **Tests**
  - Enabled a basic end-to-end test to verify Playwright availability in the CI environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->