### PR TITLE
Support JSON-LD ontology output

### DIFF
--- a/open-data-layer/docs/README.md
+++ b/open-data-layer/docs/README.md
@@ -22,3 +22,11 @@ example `rdfpipe` from rdflib:
 rdfpipe --input-format turtle ../ontology/open_data_ontology.owl \
     --query ../ontology/queries.sparql
 ```
+
+To generate the ontology in JSON-LD instead of Turtle, pass the `--format jsonld`
+flag and specify a target filename:
+
+```bash
+python ../ontology/generate_ontology.py --format jsonld \
+    ../ontology/open_data_ontology.jsonld
+```


### PR DESCRIPTION
## Summary
- extend `generate_ontology.py` to optionally output JSON-LD using `--format jsonld`
- document JSON‑LD generation in the ontology docs

## Testing
- `npm test` *(fails: SyntaxError in e2e tests)*

------
https://chatgpt.com/codex/tasks/task_e_683acd95b3f8833397c9292cda3ac1ec