### PR TITLE
Fix repo URL in src README

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -37,8 +37,8 @@ The framework includes an AI validation interface for:
 
 ```bash
 # Clone the repository
-git clone https://github.com/sheetpros/openpermit.git
-cd openpermit
+git clone https://github.com/builtbycorelot/OpenPermit.git
+cd OpenPermit
 
 # Install dependencies
 npm install


### PR DESCRIPTION
## Summary
- use canonical GitHub repo URL in `src/README.md`

## Testing
- `npm test`
- `pytest`
- `npx playwright test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684a70b37e0483339743240cf11bd8c1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions with the new repository URL and directory name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->