### PR TITLE
Add IFC validation helper

### DIFF
--- a/docs/ifc_approval.md
+++ b/docs/ifc_approval.md
@@ -25,6 +25,12 @@ This document outlines how Industry Foundation Classes (IFC) files should be val
 1. **Submission pipeline**
    - When an applicant uploads an IFC file, trigger automated validation steps before the file is accepted into the permit review queue.
    - Validation scripts can be run in a continuous integration (CI) environment or as server-side hooks.
+   - The helper script [`scripts/ifc_validate.py`](../scripts/ifc_validate.py) wraps common IfcOpenShell checks and can be executed manually:
+
+     ```bash
+     $ python scripts/ifc_validate.py example.ifc
+     IFC validation passed
+     ```
 
 2. **Feedback and reporting**
    - Collect validation results (errors, warnings, and rule violations) and store them alongside the permit record.

--- a/scripts/ifc_validate.py
+++ b/scripts/ifc_validate.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Simple wrapper around IfcOpenShell validation utilities."""
+
+import argparse
+from pathlib import Path
+import sys
+
+
+class ValidationError(Exception):
+    """Raised when the IFC file fails validation."""
+
+
+def validate_ifc(path: Path):
+    """Validate an IFC file using IfcOpenShell.
+
+    Returns a tuple ``(success, errors)``. ``success`` is ``True`` if no
+    errors were reported. ``errors`` is a list of string messages.
+    """
+
+    try:
+        import ifcopenshell
+    except ImportError as exc:
+        raise RuntimeError("IfcOpenShell is required to validate IFC files") from exc
+
+    try:
+        model = ifcopenshell.open(str(path))
+    except Exception as exc:  # pragma: no cover - depends on external library
+        return False, [f"Failed to parse IFC: {exc}"]
+
+    errors = []
+    validator = getattr(ifcopenshell, "validate", None)
+    if validator and hasattr(validator, "run_checks"):
+        try:
+            results = validator.run_checks(model)
+        except Exception as exc:  # pragma: no cover - depends on external library
+            return False, [f"Validation error: {exc}"]
+
+        for result in results:
+            if isinstance(result, dict) and result.get("severity") == "Error":
+                errors.append(result.get("message", str(result)))
+
+    return (not errors), errors
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Validate IFC using IfcOpenShell")
+    parser.add_argument("ifc_file", help="Path to IFC file")
+    args = parser.parse_args(argv)
+
+    success, errors = validate_ifc(Path(args.ifc_file))
+    if success:
+        print("IFC validation passed")
+        return 0
+
+    print("IFC validation failed:")
+    for err in errors:
+        print(f"- {err}")
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI execution
+    raise SystemExit(main())

--- a/test/scripts/test_ifc_validate.py
+++ b/test/scripts/test_ifc_validate.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+import importlib.util
+import sys
+import types
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "ifc_validate.py"
+spec = importlib.util.spec_from_file_location("ifc_validate", SCRIPT_PATH)
+ifc_validate = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ifc_validate)
+
+
+class DummyModel:
+    pass
+
+
+def _mock_ifcopenshell(valid: bool):
+    mock = types.SimpleNamespace()
+
+    def open(path):
+        return DummyModel()
+
+    validate = types.SimpleNamespace()
+
+    def run_checks(model):
+        if valid:
+            return []
+        return [{"severity": "Error", "message": "test error"}]
+
+    validate.run_checks = run_checks
+
+    mock.open = open
+    mock.validate = validate
+    return mock
+
+
+def test_validate_ifc_pass(tmp_path, monkeypatch):
+    mock = _mock_ifcopenshell(True)
+    monkeypatch.setitem(sys.modules, "ifcopenshell", mock)
+    model_path = tmp_path / "model.ifc"
+    model_path.write_text("DATA")
+
+    ok, errors = ifc_validate.validate_ifc(model_path)
+    assert ok
+    assert errors == []
+
+
+def test_validate_ifc_fail(tmp_path, monkeypatch):
+    mock = _mock_ifcopenshell(False)
+    monkeypatch.setitem(sys.modules, "ifcopenshell", mock)
+    model_path = tmp_path / "model.ifc"
+    model_path.write_text("DATA")
+
+    ok, errors = ifc_validate.validate_ifc(model_path)
+    assert not ok
+    assert errors == ["test error"]


### PR DESCRIPTION
## Summary
- add `scripts/ifc_validate.py` for running IfcOpenShell validations
- reference CLI usage in `docs/ifc_approval.md`
- create unit tests covering validation pass/fail cases

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a70bb200883338c8070dd655a17bf