### PR TITLE
Add remote inspection API stub

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,4 +6,5 @@ This directory contains supplementary documents for OpenPermit. Use the links be
 - [Mapping Building Code Requirements to IFC Elements](legal_standards_mapping.md) — Crosswalking regulations to BIM elements and automated checks.
 - [NIEM ↔ NFL Alignment (6.0)](niem-alignment-6.0.md) — Overview of schema alignment with NIEM 6.0.
 - [User Roles and Primary Actions](ui_roles.md) — Key user types and their primary actions in the system.
+- [Remote Inspection API](remote_inspections.md) — Upload geo‑tagged photos for remote site checks.
 - [References](references.md) — Policy and standards references that inform this project.

--- a/docs/remote_inspections.md
+++ b/docs/remote_inspections.md
@@ -1,0 +1,11 @@
+# Remote Inspection API
+
+The `remote_inspection` package provides a stub interface for collecting photos from the field. Each image is uploaded with latitude and longitude coordinates and undergoes a simple validation step.
+
+## Capabilities
+
+- **Upload geo‑tagged photos** – `PhotoInspectionAPI.upload_photo()` accepts a file path and GPS coordinates.
+- **Basic image validation** – files are checked with Python's `imghdr` module to ensure they are recognized images.
+- **AI hooks** – the `_run_ai_analysis()` method is a placeholder where computer‑vision models can be integrated to detect issues automatically.
+
+Uploaded photos are stored in memory as `PhotoRecord` objects containing the location and validation metadata. This stub does not persist data or handle authentication but demonstrates how remote inspections could be integrated into OpenPermit.

--- a/remote_inspection/__init__.py
+++ b/remote_inspection/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for conducting remote inspections."""
+
+from .api import PhotoInspectionAPI, PhotoRecord
+
+__all__ = ["PhotoInspectionAPI", "PhotoRecord"]

--- a/remote_inspection/api.py
+++ b/remote_inspection/api.py
@@ -1,0 +1,62 @@
+"""Stub API for uploading geo-tagged photos and validating images."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import imghdr
+from typing import Tuple, Optional, List, Dict
+
+
+@dataclass
+class PhotoRecord:
+    """Record of an uploaded photo."""
+
+    path: Path
+    location: Tuple[float, float]
+    metadata: Dict[str, object]
+
+
+class PhotoInspectionAPI:
+    """API for remote photo inspections."""
+
+    def __init__(self) -> None:
+        self.records: List[PhotoRecord] = []
+
+    def upload_photo(self, path: str | Path, lat: float, lon: float) -> PhotoRecord:
+        """Upload a photo with GPS coordinates.
+
+        Parameters
+        ----------
+        path:
+            File path to the image.
+        lat, lon:
+            Latitude and longitude.
+        Returns
+        -------
+        PhotoRecord
+            The stored photo record with validation metadata.
+        """
+        p = Path(path)
+        if not p.exists():
+            raise FileNotFoundError(p)
+
+        img_type = imghdr.what(p)
+        if img_type is None:
+            raise ValueError("Unsupported image format")
+
+        validation = {"valid": True, "format": img_type}
+        ai_result = self._run_ai_analysis(p)
+
+        record = PhotoRecord(path=p, location=(float(lat), float(lon)), metadata={
+            "validation": validation,
+            "ai": ai_result,
+        })
+        self.records.append(record)
+        return record
+
+    def _run_ai_analysis(self, path: Path) -> Optional[dict]:
+        """Placeholder for vision model inference."""
+
+        # Integrate computer vision models here (e.g., detect issues on site)
+        return None

--- a/test/remote_inspection/test_api.py
+++ b/test/remote_inspection/test_api.py
@@ -1,0 +1,29 @@
+import base64
+from pathlib import Path
+import importlib.util
+import sys
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "remote_inspection" / "api.py"
+spec = importlib.util.spec_from_file_location("remote_inspection.api", MODULE_PATH)
+api_mod = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = api_mod
+spec.loader.exec_module(api_mod)
+PhotoInspectionAPI = api_mod.PhotoInspectionAPI
+
+PNG_DATA = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAgMBAKRkYj8AAAAASUVORK5CYII="
+)
+
+
+def _write_png(tmp_path: Path) -> Path:
+    path = tmp_path / "img.png"
+    path.write_bytes(PNG_DATA)
+    return path
+
+
+def test_upload_photo(tmp_path):
+    api = PhotoInspectionAPI()
+    img = _write_png(tmp_path)
+    record = api.upload_photo(img, 1.0, 2.0)
+    assert record.location == (1.0, 2.0)
+    assert record.metadata["validation"]["valid"] is True


### PR DESCRIPTION
## Summary
- create `remote_inspection` package with photo upload stub
- integrate placeholder AI hook for vision models
- document the feature
- update docs index
- add basic unit test

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_684a70c2ca6883338055f4ab7d5ff8ab