### PR TITLE
Add audit trail utilities for workflow

### DIFF
--- a/audit.py
+++ b/audit.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+"""Simple audit trail utilities."""
+
+from datetime import datetime
+import json
+from pathlib import Path
+from typing import Iterable, List, Dict
+
+
+class AuditTrail:
+    """Append-only JSONL audit log."""
+
+    def __init__(self, log_file: Path | str = "audit.log") -> None:
+        self.log_file = Path(log_file)
+
+    def record(self, file: Path | str, user: str, action: str) -> None:
+        """Record an audit event."""
+        entry = {
+            "file": str(file),
+            "user": user,
+            "action": action,
+            "timestamp": datetime.utcnow().isoformat() + "Z",
+        }
+        self.log_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.log_file, "a", encoding="utf-8") as f:
+            json.dump(entry, f)
+            f.write("\n")
+
+    def read(self) -> List[Dict[str, str]]:
+        """Return all audit entries."""
+        if not self.log_file.exists():
+            return []
+        with open(self.log_file, "r", encoding="utf-8") as f:
+            return [json.loads(line) for line in f if line.strip()]
+

--- a/test/workflow/audit.test.py
+++ b/test/workflow/audit.test.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import importlib.util
+
+# Load audit module from repository root
+AUDIT_PATH = Path(__file__).resolve().parents[2] / "audit.py"
+spec = importlib.util.spec_from_file_location("audit", AUDIT_PATH)
+audit = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(audit)
+
+# Load submission utilities
+SUBMISSION_PATH = Path(__file__).resolve().parents[2] / "workflow" / "submission.py"
+sspec = importlib.util.spec_from_file_location("submission", SUBMISSION_PATH)
+submission = importlib.util.module_from_spec(sspec)
+sspec.loader.exec_module(submission)
+
+
+def test_create_update_log(tmp_path):
+    log_file = tmp_path / "audit.log"
+    trail = audit.AuditTrail(log_file)
+    submission_file = tmp_path / "submission.json"
+
+    submission.create_submission(submission_file, {"foo": 1}, "alice", trail)
+    submission.update_submission(submission_file, {"foo": 2}, "alice", trail)
+
+    events = trail.read()
+    assert len(events) == 2
+    assert events[0]["action"] == "create"
+    assert events[1]["action"] == "update"
+    assert events[0]["user"] == "alice"
+    assert events[0]["file"] == str(submission_file)

--- a/workflow/submission.py
+++ b/workflow/submission.py
@@ -1,0 +1,36 @@
+"""Utilities for managing workflow submissions with audit trail."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import importlib.util
+
+_AUDIT_PATH = Path(__file__).resolve().parents[1] / "audit.py"
+spec = importlib.util.spec_from_file_location("audit", _AUDIT_PATH)
+audit = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(audit)
+
+# Default audit log stored alongside this module
+_DEFAULT_TRAIL = audit.AuditTrail(Path(__file__).with_name("submission_audit.log"))
+
+
+def _write(path: Path | str, data: Any) -> None:
+    path = Path(path)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def create_submission(path: Path | str, data: Any, user: str, trail: audit.AuditTrail | None = None) -> None:
+    """Create a submission file and record an audit entry."""
+    _write(path, data)
+    (trail or _DEFAULT_TRAIL).record(path, user, "create")
+
+
+def update_submission(path: Path | str, data: Any, user: str, trail: audit.AuditTrail | None = None) -> None:
+    """Update a submission file and record an audit entry."""
+    _write(path, data)
+    (trail or _DEFAULT_TRAIL).record(path, user, "update")
+

--- a/workflow/validate_workflow.py
+++ b/workflow/validate_workflow.py
@@ -4,6 +4,8 @@ import json
 import os
 import sys
 
+import audit
+
 WORKFLOW_FILE = os.path.join(os.path.dirname(__file__), "workflow.jsonld")
 
 
@@ -30,6 +32,10 @@ def main() -> int:
         return 2
 
     print("workflow.jsonld VALID: contains @id and schema:itemListElement list")
+    user = os.environ.get("AUDIT_USER")
+    if user:
+        trail = audit.AuditTrail(os.path.join(os.path.dirname(__file__), "workflow_audit.log"))
+        trail.record(WORKFLOW_FILE, user, "validate")
     return 0
 
 


### PR DESCRIPTION
## Summary
- implement `audit.py` for logging changes with timestamps and users
- integrate audit logging in `workflow` validator
- provide `workflow/submission.py` helpers that write submissions and record audit entries
- add tests verifying audit entries on create/update

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684a70cde95c8333a272bda6bbdeab94