### PR TITLE
Add roadmap documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,9 @@ PRs welcome!
 ---
 
 ## Links & References
-* Docs portal – [`docs/`](docs/)  
-* Full reference list – [`docs/references.md`](docs/references.md)  
-* Public site – <https://builtbycorelot.github.io/OpenPermit>  
+* Docs portal – [`docs/`](docs/)
+* Full reference list – [`docs/references.md`](docs/references.md)
+* Project roadmap – [`docs/roadmap.md`](docs/roadmap.md)
+* Public site – <https://builtbycorelot.github.io/OpenPermit>
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,4 @@ This directory contains supplementary documents for OpenPermit. Use the links be
 - [NIEM ↔ NFL Alignment (6.0)](niem-alignment-6.0.md) — Overview of schema alignment with NIEM 6.0.
 - [User Roles and Primary Actions](ui_roles.md) — Key user types and their primary actions in the system.
 - [References](references.md) — Policy and standards references that inform this project.
+- [Project Roadmap](roadmap.md) — Upcoming milestones including the API façade and CKAN integration.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,18 @@
+# Project Roadmap
+
+This roadmap outlines near-term milestones to evolve OpenPermit into a mandate-ready reference implementation.
+
+## API façade
+- Provide thin wrappers around existing modules so that permit data can be queried and updated over a REST or GraphQL API.
+- These wrappers don't need complex business logic initially; their purpose is to expose the standards-first data layer through a stable interface.
+
+## CKAN open-data push
+- Finish the integration scripts that publish validated permit datasets to any CKAN portal.
+- Ensure metadata and access controls propagate correctly so agencies can meet open-data requirements.
+
+## Alpha release and FedRAMP-ready container
+- Package the project as a container with dependencies locked down.
+- Follow FedRAMP guidance for base images and hardening so agencies can evaluate deployment.
+- Tag the release as an "alpha" to gather feedback while signalling early stability.
+
+These efforts will move OpenPermit from a proof of concept to a practical toolkit that agencies can adopt.


### PR DESCRIPTION
## Summary
- add new `docs/roadmap.md` with API facade, CKAN push, and FedRAMP container milestones
- link the roadmap from `docs/README.md` and main `README.md`

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_684a71162fe48333a622022eb7e3d2e1