### PR TITLE
Add Node Form Language standards plan

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ This directory contains supplementary documents for OpenPermit. Use the links be
 - [IFC File Validation Workflow](ifc_approval.md) — How to check IFC models before submission.
 - [Mapping Building Code Requirements to IFC Elements](legal_standards_mapping.md) — Crosswalking regulations to BIM elements and automated checks.
 - [NIEM ↔ NFL Alignment (6.0)](niem-alignment-6.0.md) — Overview of schema alignment with NIEM 6.0.
+- [Node Form Language – Standards Grounding Plan](nfl-standards-plan.md) — How NFL ties into ISO 27001, NIEM and related standards.
 - [User Roles and Primary Actions](ui_roles.md) — Key user types and their primary actions in the system.
 - [Remote Inspection API](remote_inspections.md) — Upload geo‑tagged photos for remote site checks.
 - [References](references.md) — Policy and standards references that inform this project.

--- a/docs/nfl-standards-plan.md
+++ b/docs/nfl-standards-plan.md
@@ -1,0 +1,13 @@
+# Node Form Language – Standards Grounding Plan
+
+This plan outlines how the Node Form Language (NFL) aligns with widely adopted standards to ensure secure and interoperable permitting workflows. Each referenced standard influences the structure or security posture of the NFL schemas.
+
+## Core Standards
+
+- **ISO/IEC 27001:2022** — Establishes the information security management controls used when handling permit data.
+- **NIEM 6.0** — Provides the base vocabulary for exchanging data with federal and state systems.
+- **ISO 19650** — Guides the organization of BIM documents linked from NFL nodes.
+- **CityJSON / OGC InfraGML** — Supports geospatial features present in site plans and inspections.
+- **NIST SP 800‑53** — Supplies security and privacy controls for API and workflow implementations.
+
+Together these references ground the Node Form Language in well known industry practices while remaining flexible for local requirements.

--- a/nfl/standards/standards.jsonld
+++ b/nfl/standards/standards.jsonld
@@ -1,0 +1,41 @@
+{
+  "@context": {
+    "schema": "https://schema.org/",
+    "nfl": "https://openpermit.org/ns/nfl#"
+  },
+  "@id": "nfl:StandardsCatalog",
+  "@type": "schema:ItemList",
+  "schema:name": "Node Form Language Standards",
+  "schema:itemListElement": [
+    {
+      "@id": "nfl:ISO27001",
+      "@type": "schema:CreativeWork",
+      "schema:name": "ISO/IEC 27001:2022 Information Security Management",
+      "schema:url": "https://www.iso.org/standard/27001.html"
+    },
+    {
+      "@id": "nfl:NIEM6.0",
+      "@type": "schema:CreativeWork",
+      "schema:name": "NIEM Release 6.0",
+      "schema:url": "https://niem.github.io/niem-releases/"
+    },
+    {
+      "@id": "nfl:ISO19650",
+      "@type": "schema:CreativeWork",
+      "schema:name": "ISO 19650 Building Information Management",
+      "schema:url": "https://www.iso.org/standard/68078.html"
+    },
+    {
+      "@id": "nfl:CityJSON",
+      "@type": "schema:CreativeWork",
+      "schema:name": "CityJSON 1.1",
+      "schema:url": "https://www.cityjson.org/"
+    },
+    {
+      "@id": "nfl:NIST80053",
+      "@type": "schema:CreativeWork",
+      "schema:name": "NIST SP 800-53 Revision 5",
+      "schema:url": "https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Node Form Language standards grounding plan document
- link the plan from the docs index
- include a JSON‑LD catalogue of key standards referenced by NFL

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_685f241a3d188333a709efa6e6f228ed