### PR TITLE
Fix audit path for workflow validator

### DIFF
--- a/workflow/validate_workflow.py
+++ b/workflow/validate_workflow.py
@@ -3,10 +3,12 @@
 import json
 import os
 import sys
+from pathlib import Path
 
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 import audit
 
-WORKFLOW_FILE = os.path.join(os.path.dirname(__file__), "workflow.jsonld")
+WORKFLOW_FILE = str(Path(__file__).resolve().with_name("workflow.jsonld"))
 
 
 def main() -> int:
@@ -34,7 +36,7 @@ def main() -> int:
     print("workflow.jsonld VALID: contains @id and schema:itemListElement list")
     user = os.environ.get("AUDIT_USER")
     if user:
-        trail = audit.AuditTrail(os.path.join(os.path.dirname(__file__), "workflow_audit.log"))
+        trail = audit.AuditTrail(Path(__file__).resolve().with_name("workflow_audit.log"))
         trail.record(WORKFLOW_FILE, user, "validate")
     return 0
 


### PR DESCRIPTION
## Summary
- ensure `workflow/validate_workflow.py` resolves `audit.py` from repo root
- update audit logging path

## Testing
- `python workflow/validate_workflow.py`
- `cd /tmp && python /workspace/OpenPermit/workflow/validate_workflow.py`

------
https://chatgpt.com/codex/tasks/task_e_687053cb67c08333928edebbaaba826d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated internal file path handling for improved reliability and consistency. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->